### PR TITLE
Solve typo in ref man

### DIFF
--- a/manual/refman/exten.etex
+++ b/manual/refman/exten.etex
@@ -373,7 +373,7 @@ the parameter by a `"+"' or a `"-"', it is invariant otherwise.
 
 \begin{syntax}
 type-equation:
-          ...
+          ...w
         | '=' 'private' typexpr
 \end{syntax}
 
@@ -1604,7 +1604,7 @@ Some attributes are understood by the type-checker:
 
 \begin{verbatim}
 module X = struct
-  [@@warning "+9"]  (* locally enable warning 9 in this structure *)
+  [@@@warning "+9"]  (* locally enable warning 9 in this structure *)
   ...
 end
 


### PR DESCRIPTION
In the provided example, the attribute should be a floating attribute, not an block attributed.
